### PR TITLE
Fix creep rotation

### DIFF
--- a/scripts/Core/Graphics.js
+++ b/scripts/Core/Graphics.js
@@ -63,7 +63,7 @@ DTD.graphics = (function() {
 		context.save();
 		
 		context.translate(spec.center.x, spec.center.y);
-		context.rotate(-spec.rotation);
+		context.rotate(spec.rotation);
 		context.translate(-spec.center.x, -spec.center.y);
 		
         context.globalAlpha = spec.opacity;
@@ -82,12 +82,16 @@ DTD.graphics = (function() {
 	//
 	//------------------------------------------------------------------
 	function drawRectangle(spec) {
-		context.fillStyle = spec.fill;
     context.globalAlpha = spec.opacity||1;
-		context.fillRect(spec.x, spec.y, spec.width, spec.height);
-
-		context.strokeStyle = spec.stroke;
-		context.strokeRect(spec.x, spec.y, spec.width, spec.height);
+    if ('fill' in spec) {
+      context.fillStyle = spec.fill;
+      context.fillRect(spec.x, spec.y, spec.width, spec.height);
+    }
+    
+    if ('stroke' in spec) {
+      context.strokeStyle = spec.stroke;
+      context.strokeRect(spec.x, spec.y, spec.width, spec.height);
+    }
     context.globalAlpha = 1;
 	}
 

--- a/scripts/Core/Graphics.js
+++ b/scripts/Core/Graphics.js
@@ -76,12 +76,12 @@ DTD.graphics = (function() {
 		context.restore();
 	}
   
-	//------------------------------------------------------------------
-	//
-	// Draws a rectangle
-	//
-	//------------------------------------------------------------------
-	function drawRectangle(spec) {
+  //------------------------------------------------------------------
+  //
+  // Draws a rectangle
+  //
+  //------------------------------------------------------------------
+  function drawRectangle(spec) {
     context.globalAlpha = spec.opacity||1;
     if ('fill' in spec) {
       context.fillStyle = spec.fill;
@@ -93,7 +93,7 @@ DTD.graphics = (function() {
       context.strokeRect(spec.x, spec.y, spec.width, spec.height);
     }
     context.globalAlpha = 1;
-	}
+  }
 
 	//------------------------------------------------------------------
 	//

--- a/scripts/Gameplay/Components.js
+++ b/scripts/Gameplay/Components.js
@@ -253,6 +253,18 @@ DTD.components = (function(graphics) {
       nextPoint,
       pathFunction;
       spec.opacity = 1;
+      spec.initialLifePoints = spec.lifePoints;
+      
+      that.hit = function(damage) {
+        spec.lifePoints -= damage;
+        if (spec.lifePoints <= 0) {
+          spec.lifePoints = 0;
+        }
+      }
+      
+      that.alive = function() {
+        return spec.lifePoints > 0;
+      }
       
       that.setPathFindingFunction = function(f) {
         pathFunction = f;
@@ -263,7 +275,12 @@ DTD.components = (function(graphics) {
       }
       
       that.update = function(elapsedTime) {
-        if (elapsedTime < 0) {
+        // This is only to demonstrate life point functionality and should be removed
+        if (elapsedTime > 100) {
+          that.hit(1);
+        }
+
+        if (elapsedTime < 0 || !that.alive()) {
           return;
         }
         sprite.update(elapsedTime, true);
@@ -282,7 +299,7 @@ DTD.components = (function(graphics) {
               x: direction.x / length,
               y: direction.y / length
             },
-            angle = Math.atan(-direction.y / direction.x);
+            angle = Math.atan(direction.y / direction.x);
           if (direction.x < 0) {
             angle += Math.PI;
           }
@@ -315,7 +332,26 @@ DTD.components = (function(graphics) {
       }
 
       that.render = function() {
-        sprite.draw();
+        if (that.alive()) {
+          var percentLife = spec.lifePoints / spec.initialLifePoints,
+            greenWidth = spec.width * percentLife,
+            redWidth = spec.width * (1 - percentLife);
+          sprite.draw();
+          graphics.drawRectangle({
+            fill: 'rgba(0,255,0,1)',
+            x: spec.center.x - spec.width / 2,
+            y: spec.center.y - spec.height / 2 - 10,
+            width: greenWidth,
+            height: 4
+          });
+          graphics.drawRectangle({
+            fill: 'rgba(255,0,0,1)',
+            x: spec.center.x - spec.width / 2 + greenWidth,
+            y: spec.center.y - spec.height / 2 - 10,
+            width: redWidth,
+            height: 4
+          });
+        }
       }
 
       return that;
@@ -774,6 +810,7 @@ DTD.components = (function(graphics) {
       rotateSpeed: 40 / 4,
       width: Constants.CreepWidth,
       height: Constants.CreepHeight,
+      lifePoints: 40,
       exitNumber: spec.exitNumber,
       speed: 40,
       spriteCount: 6,
@@ -789,6 +826,7 @@ DTD.components = (function(graphics) {
       rotateSpeed: 40 / 3,
       width: Constants.CreepWidth,
       height: Constants.CreepHeight,
+      lifePoints: 35,
       exitNumber: spec.exitNumber,
       speed: 50,
       spriteCount: 4,
@@ -804,6 +842,7 @@ DTD.components = (function(graphics) {
       rotateSpeed: 40 / 2,
       width: Constants.CreepWidth,
       height: Constants.CreepHeight,
+      lifePoints: 30,
       exitNumber: spec.exitNumber,
       speed: 60,
       spriteCount: 4,

--- a/scripts/Gameplay/Components.js
+++ b/scripts/Gameplay/Components.js
@@ -1,82 +1,76 @@
 
 DTD.components = (function(graphics) {
 
-	//------------------------------------------------------------------
-	//
-	// Tests to see if two rectangles intersect.  If they do, true is returned,
-	// false otherwise.
-	// Adapted from: http://stackoverflow.com/questions/2752349/fast-rectangle-to-rectangle-intersection
-	//
-	//------------------------------------------------------------------
-	function intersectRectangles(r1, r2) {
-		return !(
-			r2.left > r1.right ||
-			r2.right < r1.left ||
-			r2.top > r1.bottom ||
-			r2.bottom < r1.top
-		);
-	}
+  //------------------------------------------------------------------
+  //
+  // Tests to see if two rectangles intersect.  If they do, true is returned,
+  // false otherwise.
+  // Adapted from: http://stackoverflow.com/questions/2752349/fast-rectangle-to-rectangle-intersection
+  //
+  //------------------------------------------------------------------
+  function intersectRectangles(r1, r2) {
+    return !(
+      r2.left > r1.right ||
+      r2.right < r1.left ||
+      r2.top > r1.bottom ||
+      r2.bottom < r1.top
+    );
+  }
   
   //------------------------------------------------------------------
-	//
-	// Tests to see if two rectangles intersect.  If they do, true is returned,
-	// false otherwise.
-	// Adapted from: http://stackoverflow.com/questions/2752349/fast-rectangle-to-rectangle-intersection
-	//
-	//------------------------------------------------------------------
-	function overlapRectangles(r1, r2) {
-		return (
-			r2.left < r1.right &&
-			r2.right > r1.left &&
-			r2.top < r1.bottom &&
-			r2.bottom > r1.top
-		);
-	}
-  
+  //
+  // Tests to see if two rectangles intersect.  If they do, true is returned,
+  // false otherwise.
+  // Adapted from: http://stackoverflow.com/questions/2752349/fast-rectangle-to-rectangle-intersection
+  //
+  //------------------------------------------------------------------
+  function overlapRectangles(r1, r2) {
+    return (
+      r2.left < r1.right &&
+      r2.right > r1.left &&
+      r2.top < r1.bottom &&
+      r2.bottom > r1.top
+    );
+  }
   
   function intersectPoint(r, p) {
-		return (
-			p.x < r.right &&
-			p.x > r.left &&
-			p.y < r.bottom &&
-			p.y > r.top
-		);
-	}
+    return (
+      p.x < r.right &&
+      p.x > r.left &&
+      p.y < r.bottom &&
+      p.y > r.top
+    );
+  }
   
-  
-	//
-	// Constants, as best as we can do them in JavaScript
-	var Constants = {
+  //
+  // Constants, as best as we can do them in JavaScript
+  var Constants = {
     get GridHeight() { return 20; },
     get GridWidth() { return 20; },
     get CreepHeight() { return 40; },
     get CreepWidth() { return 40; },
     get TowerHeight() { return 40; },
     get TowerWidth() { return 40; },
-	};
+  };
   
   function Texture(imageSrc) {
-		var that = {},
-			ready = false,
-			image = new Image();
-		
-		// Load the image; override the draw function once it finished loading.
-		image.onload = function() { 
-            that.draw = function(spec) {
-                graphics.drawImage(image, spec);
-            };
-		};
-		image.src = imageSrc;
-		
-		// that.updateRotation = function(angle) {
-		// 	spec.rotation += angle;
-		// };
-		
-		that.draw = function() {
-		};
-		
-		return that;
-	}
+    var that = {},
+      ready = false,
+      image = new Image();
+    
+    // Load the image; override the draw function once it finished loading.
+    image.onload = function() { 
+      that.draw = function(spec) {
+        graphics.drawImage(image, spec);
+      };
+    };
+    image.src = imageSrc;
+    
+    that.draw = function() {
+    };
+    
+    return that;
+  }
   
   // ------------------------------------------------------------------
     //
@@ -87,36 +81,37 @@ DTD.components = (function(graphics) {
     //
     // ------------------------------------------------------------------
     function Tower(spec) {
-        var that = {
-            get left() { return spec.center.x - Constants.TowerWidth / 2 },
-            get right() { return spec.center.x + Constants.TowerWidth / 2 },
-            get top() { return spec.center.y - Constants.TowerHeight / 2 },
-            get bottom() { return spec.center.y + Constants.TowerHeight / 2 },
-            get center() { return spec.center },
-      get rotation() { return spec.rotation },
-      set centerX(value) { spec.center.x = value },
-      set centerY(value) { spec.center.y = value },
-      set validPosition(value) { validPosition = value},
-      get validPosition() { return validPosition;},
-      set highlight(value) {highlight = value;},
-      get highlight() {return highlight;}
-        },
+      var that = {
+        get left() { return spec.center.x - Constants.TowerWidth / 2 },
+        get right() { return spec.center.x + Constants.TowerWidth / 2 },
+        get top() { return spec.center.y - Constants.TowerHeight / 2 },
+        get bottom() { return spec.center.y + Constants.TowerHeight / 2 },
+        get center() { return spec.center },
+        get rotation() { return spec.rotation },
+        set centerX(value) { spec.center.x = value },
+        set centerY(value) { spec.center.y = value },
+        set validPosition(value) { validPosition = value},
+        get validPosition() { return validPosition;},
+        set highlight(value) {highlight = value;},
+        get highlight() {return highlight;}
+      },
         highlight = false,
-            texture = Texture(spec.image),
-            targetRotation = spec.rotation,
-            rotateSpeed = spec.rotateSpeed,
-            validPosition = true;
+        texture = Texture(spec.image),
+        targetRotation = spec.rotation,
+        rotateSpeed = spec.rotateSpeed,
+        validPosition = true;
         
         that.placed = false;
         that.setRotationSpeed = function(speed){
           rotateSpeed = speed;
         }
+        
         that.setRotation = function(rotation) {
-            targetRotation = rotation%(2*Math.PI);
+          targetRotation = rotation%(2*Math.PI);
         }
         
         function updatePlacing(elapsedTime) {
-            validPosition = true;
+          validPosition = true;
         }
         
         function updatePlaced(elapsedTime) {
@@ -129,40 +124,39 @@ DTD.components = (function(graphics) {
         }
 
         function renderPlacing() {
-            var squareFill;
-            if (validPosition) {
-                squareFill = 'rgba(0, 255, 0, 0.4)';
-            }
-            else {
-                squareFill = 'rgba(255, 0, 0, 0.4)';
-            }
-            graphics.drawCircle({
-                center: spec.center,
-                radius: spec.radius,
-                fill: 'rgba(200, 200, 200, 0.4)',
-                stroke: 'rgba(150, 150, 150, 0.4)'
-            });
-            graphics.drawRectangle({
-                x: spec.center.x - Constants.TowerWidth / 2,
-                y: spec.center.y - Constants.TowerHeight / 2,
-                width: Constants.TowerWidth,
-                height: Constants.TowerHeight,
-                fill: squareFill
-            })
-            texture.draw({
-                center: spec.center,
-                width: Constants.TowerWidth,
-                height: Constants.TowerHeight,
-                rotation: spec.rotation,
-                opacity: 0.4
-            });
+          var squareFill;
+          if (validPosition) {
+            squareFill = 'rgba(0, 255, 0, 0.4)';
+          }
+          else {
+            squareFill = 'rgba(255, 0, 0, 0.4)';
+          }
+          graphics.drawCircle({
+            center: spec.center,
+            radius: spec.radius,
+            fill: 'rgba(200, 200, 200, 0.4)',
+            stroke: 'rgba(150, 150, 150, 0.4)'
+          });
+          graphics.drawRectangle({
+            x: spec.center.x - Constants.TowerWidth / 2,
+            y: spec.center.y - Constants.TowerHeight / 2,
+            width: Constants.TowerWidth,
+            height: Constants.TowerHeight,
+            fill: squareFill
+          })
+          texture.draw({
+            center: spec.center,
+            width: Constants.TowerWidth,
+            height: Constants.TowerHeight,
+            rotation: spec.rotation,
+            opacity: 0.4
+          });
         }
         
         function renderPlaced() {
           var f;
           if(highlight){
             f=spec.baseColor;
-            
           }
           else {
             f='gray';
@@ -176,47 +170,47 @@ DTD.components = (function(graphics) {
             stroke: spec.baseColor,
             fill: f,
             opacity: 0.4
-          })
-            texture.draw({
-                center: spec.center,
-                width: Constants.TowerWidth,
-                height: Constants.TowerHeight,
-                rotation: spec.rotation,
-                opacity: 1
-            });
+          });
+          texture.draw({
+            center: spec.center,
+            width: Constants.TowerWidth,
+            height: Constants.TowerHeight,
+            rotation: spec.rotation,
+            opacity: 1
+          });
         }
         
         function renderSelected() {
-            graphics.drawCircle({
-                center: spec.center,
-                radius: spec.radius,
-                fill: 'rgba(200, 200, 200, 0.4)',
-                stroke: 'rgba(100, 100, 100, 1)'
-            });
-            renderPlaced();
+          graphics.drawCircle({
+            center: spec.center,
+            radius: spec.radius,
+            fill: 'rgba(200, 200, 200, 0.4)',
+            stroke: 'rgba(100, 100, 100, 1)'
+          });
+          renderPlaced();
         }
 
         that.update = updatePlacing;
         that.render = renderPlacing;
         
         that.place = function() {
-            if (!that.placed && validPosition) {
-                that.placed = true;
-                that.render = renderPlaced;
-                that.update = updatePlaced;
-            }
+          if (!that.placed && validPosition) {
+            that.placed = true;
+            that.render = renderPlaced;
+            that.update = updatePlaced;
+          }
         }
         
         that.select = function() {
-            if (that.placed) {
-                that.render = renderSelected;
-            }
+          if (that.placed) {
+           that.render = renderSelected;
+          }
         }
         
         that.unselect = function() {
-            if (that.placed) {
-                that.render = renderPlaced;
-            }
+          if (that.placed) {
+            that.render = renderPlaced;
+          }
         }
 
         return that;
@@ -286,6 +280,13 @@ DTD.components = (function(graphics) {
           return;
         }
         sprite.update(elapsedTime, true);
+        do {
+          updateTargets();
+          elapsedTime -= rotateAndMove(elapsedTime);
+        } while (elapsedTime > 0);
+      }
+      
+      function updateTargets() {
         nextPoint = pathFunction(spec.exitNumber, spec.center);
         if (nextPoint.x !== targetPosition.x || nextPoint.y !== targetPosition.y) {
           targetPosition = nextPoint;
@@ -298,50 +299,67 @@ DTD.components = (function(graphics) {
             if (direction.x < 0) {
               targetRotation += Math.PI;
             }
+            else if (targetRotation < 0) {
+              targetRotation += 2 * Math.PI;
+            }
           } else {
-            targetRotation = -Math.PI / 2;
+            targetRotation = Math.PI / 2;
           }
         }
-        moveTo(targetPosition, elapsedTime);
       }
       
-      function moveTo(point, elapsedTime) {
-        if (spec.center.x !== point.x || spec.center.y !== point.y) {
-          var direction, length, normalized;
-          
-          if (Math.abs(targetRotation - spec.rotation) < .00001) { // compare doubles with epsilon of .00001
-            direction = {
-              x: point.x - spec.center.x,
-              y: point.y - spec.center.y
-            };
-            length = Math.sqrt(direction.x * direction.x + direction.y * direction.y);
-            normalized = {
-              x: direction.x / length,
-              y: direction.y / length
-            }
-            spec.center.x += Math.sign(direction.x) * Math.min(Math.abs(normalized.x * (spec.speed * (elapsedTime / 1000))), Math.abs(direction.x));
-            spec.center.y += Math.sign(direction.y) * Math.min(Math.abs(normalized.y * (spec.speed * (elapsedTime / 1000))), Math.abs(direction.y));
-            // if (spec.center.x === point.x && spec.center.y === point.y) {
-            //   console.log("Arrived at point: " + point.x + ", " + point.y);
-            // }
+      // Returns the amount of time "spent" rotating and moving
+      function rotateAndMove(elapsedTime) {
+        if (spec.center.x !== targetPosition.x || spec.center.y !== targetPosition.y) {
+          var direction, length, normalized,
+            remainingTime = elapsedTime,
+            remainingSecs = elapsedTime / 1000,
+            diff = (targetRotation - spec.rotation) % (2 * Math.PI);
+            
+          if(diff > Math.PI){
+            diff = Math.PI - diff;
           }
-          else {
-            var diff = (targetRotation - spec.rotation) % (2 * Math.PI);
-            if(diff > Math.PI){
-              diff = Math.PI - diff;
+          
+          if (Math.abs(diff) > .00001) { // compare doubles with epsilon of .00001
+            var maxRotate = spec.rotateSpeed * remainingSecs;
+            if (spec.rotateSpeed * remainingSecs < Math.abs(diff)) {
+              spec.rotation += Math.sign(diff) * maxRotate;
+              return elapsedTime;
             }
-            var step = Math.sign(diff) * Math.min(spec.rotateSpeed * (elapsedTime / 1000), Math.abs(diff));
-            spec.rotation += step;
-            if (spec.rotation < -Math.PI / 2) {
-              spec.rotation += 2 * Math.PI;
-            }
-            else if (spec.rotation > 3 * Math.PI / 2) {
-              spec.rotation -= 2 * Math.PI;
+            else {
+              spec.rotation += diff;
+              remainingTime -= elapsedTime * ((maxRotate - Math.abs(diff)) / maxRotate);
+              remainingSecs = remainingTime / 1000;
             }
             // if (Math.abs(spec.rotation - angle) < .00001) {
             //   console.log("Arrived at angle: " + (angle / Math.PI) + "*PI");
             // }
           }
+          
+          var maxDistance = spec.speed * remainingSecs;
+          direction = {
+            x: targetPosition.x - spec.center.x,
+            y: targetPosition.y - spec.center.y
+          };
+          length = Math.sqrt(direction.x * direction.x + direction.y * direction.y);
+          normalized = {
+            x: direction.x / length,
+            y: direction.y / length
+          };
+          if (maxDistance < length) {
+            spec.center.x += normalized.x * maxDistance;
+            spec.center.y += normalized.y * maxDistance;
+            return elapsedTime;
+          } else {
+            spec.center.x += direction.x;
+            spec.center.y += direction.y;
+            remainingTime -= elapsedTime * ((maxDistance - length) / maxDistance);
+            remainingSecs = remainingTime / 1000;
+          }
+          // if (spec.center.x === targetPosition.x && spec.center.y === targetPosition.y) {
+          //   console.log("Arrived at point: " + targetPosition.x + ", " + targetPosition.y);
+          // }
+          return elapsedTime - remainingTime;
         }
       }
 
@@ -718,7 +736,7 @@ DTD.components = (function(graphics) {
 
     entrances.push({in:{i:0,j:14},out:{i:29, j:14}});
     entrances.push({in:{i:15,j:0},out:{i:15, j:29}});
-
+    
     clearPaths = function(theGrid){
       for(var i=0; i<spec.width/Constants.GridWidth; i++){
         var gridLine = [];
@@ -824,7 +842,7 @@ DTD.components = (function(graphics) {
       spriteSheet: 'images/creep/creep-1-blue/spriteSheet.png',
       rotation: 0,
       center: {x:2,y:2},
-      rotateSpeed: 40 / 4,
+      rotateSpeed: Math.PI / 2,
       width: Constants.CreepWidth,
       height: Constants.CreepHeight,
       lifePoints: 40,
@@ -840,7 +858,7 @@ DTD.components = (function(graphics) {
       spriteSheet: 'images/creep/creep-2-green/spriteSheet.png',
       rotation: 0,
       center: {x:2,y:2},
-      rotateSpeed: 40 / 3,
+      rotateSpeed: Math.PI / 3,
       width: Constants.CreepWidth,
       height: Constants.CreepHeight,
       lifePoints: 35,
@@ -854,9 +872,9 @@ DTD.components = (function(graphics) {
   function Creep_3(spec) {
     return Creep({
       spriteSheet: 'images/creep/creep-3-red/spriteSheet.png',
-      rotation: 0,
+      rotation: Math.PI / 2,
       center: {x:2,y:2},
-      rotateSpeed: 40 / 2,
+      rotateSpeed: Math.PI / 4,
       width: Constants.CreepWidth,
       height: Constants.CreepHeight,
       lifePoints: 30,
@@ -868,7 +886,7 @@ DTD.components = (function(graphics) {
   }
 
 
-	return {
+  return {
     Tower : Tower,
     Tower_1 : Tower_1,
     Tower_2 : Tower_2,
@@ -879,8 +897,8 @@ DTD.components = (function(graphics) {
     Creep_1 : Creep_1,
     Creep_2 : Creep_2,
     Creep_3 : Creep_3,
-		Constants: Constants,
-		Map : Map,
+    Constants: Constants,
+    Map : Map,
     ToolBox : ToolBox
-	};
+  };
 }(DTD.graphics));


### PR DESCRIPTION
A lot of this pull is just fixing spacing weirdness.
Down toward the bottom are the real changes:
We now only update the targetRotation and targetPosition when we are given a new one.
We also will rotate and/or move for the full allotment of time in the frame, looping as necessary.

Make sure my math/logic is correct. (I finally realized what you were saying about the y messing things up. So basically the y-axis is inverted, which does change the direction of rotation to clockwise.)
@austinstoker 